### PR TITLE
HS-5 - Add public dns name

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -20,6 +20,7 @@ on:
 
 # Add a workflow-level env block for common secrets and variables
 env:
+  WORKFLOW_NAME: ${{ github.workflow }} - ${{ github.event_name }} - ${{ github.ref_name }}
   ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
   ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
   ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}

--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,7 @@ resource "azurerm_public_ip" "main" {
   name                = "pip-hylastix"
   location            = var.location
   resource_group_name = azurerm_resource_group.main.name
+  domain_name_label   = "hylastix-test"
   allocation_method   = "Static"
   sku                 = "Basic"
 }


### PR DESCRIPTION
This pull request introduces updates to the Terraform workflow and configuration files to enhance workflow metadata and resource configuration. The most notable changes include adding a descriptive workflow name to the environment variables and specifying a domain name label for the Azure public IP resource.

### Workflow enhancements:
* [`.github/workflows/terraform.yaml`](diffhunk://#diff-5125e64cb591a598774a1b20f8fee8e4551204441592cbbbf523b9eb9c10cf3eR23): Added a `WORKFLOW_NAME` environment variable to include the workflow name, event name, and reference name for better identification and debugging.

### Resource configuration updates:
* [`main.tf`](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR42): Added a `domain_name_label` property to the `azurerm_public_ip` resource to set a custom domain name label (`hylastix-test`).